### PR TITLE
Fix stacking behaviour for some items in creative

### DIFF
--- a/mods/fl_agriculture/crops/carrot.lua
+++ b/mods/fl_agriculture/crops/carrot.lua
@@ -13,7 +13,11 @@ minetest.register_craftitem("fl_agriculture:carrot", {
         if minetest.get_item_group(node.name, "plantable") ~= 1 then return end
         if minetest.registered_nodes[anode.name].drawtype ~= "airlike" then return end
         minetest.set_node({x=pos.x, y=pos.y+1,z=pos.z}, {name = "fl_agriculture:carrot_1", param2 = 3})
-        itemstack:take_item()
+        if not (placer and placer:is_player()
+            and minetest.is_creative_enabled(placer:get_player_name()))
+        then
+            itemstack:take_item()
+        end
         return itemstack
     end,
     _dungeon_loot = {name = "fl_agriculture:carrot", chance = 0.6, count = {3, 6}},

--- a/mods/fl_agriculture/crops/potato.lua
+++ b/mods/fl_agriculture/crops/potato.lua
@@ -13,7 +13,11 @@ minetest.register_craftitem("fl_agriculture:potato", {
         if minetest.get_item_group(node.name, "plantable") ~= 1 then return end
         if minetest.registered_nodes[anode.name].drawtype ~= "airlike" then return end
         minetest.set_node({x=pos.x, y=pos.y+1,z=pos.z}, {name = "fl_agriculture:potato_1", param2 = 3})
-        itemstack:take_item()
+        if not (placer and placer:is_player()
+            and minetest.is_creative_enabled(placer:get_player_name()))
+        then
+            itemstack:take_item()
+        end
         return itemstack
     end,
     _dungeon_loot = {name = "fl_agriculture:potato", chance = 0.6, count = {3, 6}},

--- a/mods/fl_bottles/init.lua
+++ b/mods/fl_bottles/init.lua
@@ -94,7 +94,23 @@ minetest.register_craftitem("fl_bottles:invisibility", {
             end
         )
 
-        itemstack:take_item()
+        if not (placer and placer:is_player()
+            and minetest.is_creative_enabled(placer:get_player_name()))
+        then
+            itemstack:take_item()
+        end
         return itemstack
     end,
 })
+
+minetest.register_on_leaveplayer(function(player, _)
+    player:get_meta():set_int("vanish", 0)
+    player:get_meta():set_int("in_vanish", 0)
+end)
+
+minetest.register_on_shutdown(function()
+    for _, player in pairs(minetest.get_connected_players()) do
+        player:get_meta():set_int("vanish", 0)
+        player:get_meta():set_int("in_vanish", 0)
+    end
+end)

--- a/mods/fl_light_sources/init.lua
+++ b/mods/fl_light_sources/init.lua
@@ -80,18 +80,13 @@ minetest.register_node("fl_light_sources:lantern", {
             {-3/16, -0.5, -3/16, 3/16, 0, 3/16},
         },
     },
-    on_place = function(itemstack, placer, pointed_thing)
+   on_place = function(itemstack, placer, pointed_thing)
         if pointed_thing.type ~= "node" then return end
         if pointed_thing.under.y-pointed_thing.above.y == 1 then
-            local stack = ItemStack(itemstack)
-            stack:set_name("fl_light_sources:lantern_c")
-            minetest.item_place(stack, placer, pointed_thing)
-            itemstack:take_item()
-            return itemstack
+            -- This does not mutate the original stack
+            itemstack:set_name("fl_light_sources:lantern_c")
         end
         minetest.item_place(itemstack, placer, pointed_thing)
-        itemstack:take_item()
-        return itemstack
     end,
     groups = {dig_stone = 2, lantern = 1}
 })

--- a/mods/fl_topsoil/topsoil.lua
+++ b/mods/fl_topsoil/topsoil.lua
@@ -139,8 +139,6 @@ minetest.register_node("fl_topsoil:snow", {
                 minetest.add_item(pos, inv_add)
             end
         end
-        return itemstack
-
     end,
     on_place = function(itemstack, player, pointed_thing)
         local under_node = minetest.get_node_or_nil(pointed_thing.under)

--- a/mods/fl_trains/engine.lua
+++ b/mods/fl_trains/engine.lua
@@ -217,6 +217,13 @@ minetest.register_entity("fl_trains:train_engine", {
 
     on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
         self.object:remove()
+        if not (puncher and puncher:is_player()) then return end
+        local inv = puncher:get_inventory()
+        if minetest.is_creative_enabled(puncher:get_player_name())
+            and inv:contains_item("main", "fl_trains:train_engine")
+        then return end
+
+        inv:add_item("main", "fl_trains:train_engine")
     end,
 
     on_rightclick=function(self, clicker)
@@ -260,7 +267,14 @@ minetest.register_craftitem("fl_trains:train_engine", {
                     ent:set_rotation(vector.new(0,deg_to_rad(-45),0))
                 end
             end
+
+            if not (placer and placer:is_player()
+                and minetest.is_creative_enabled(placer:get_player_name()))
+            then
+                itemstack:take_item()
+            end
         end
+        return itemstack
     end,
     groups = {not_in_creative_inventory = 1}
 })

--- a/mods/fl_workshop/saw.lua
+++ b/mods/fl_workshop/saw.lua
@@ -211,7 +211,11 @@ minetest.register_node(":fl_stairs:tablesaw", {
         and pointed_thing.type == "node"
         and minetest.get_modpath("fl_tnt") then
             fl_tnt.boom(pointed_thing.under, {radius = 3})
-            itemstack:take_item()
+            if not (placer and placer:is_player()
+                and minetest.is_creative_enabled(placer:get_player_name()))
+            then
+                itemstack:take_item()
+            end
             --placer:set_wielded_item(itemstack)
             return itemstack
         end


### PR DESCRIPTION
* Some were removed when placed, even in creative mode.
* The lantern was removed twice in survival!
* Digging snow always gave the player snow, even in creative.
